### PR TITLE
change hook for keyboard_shortcut script to wp_footer

### DIFF
--- a/bottom-admin-bar.php
+++ b/bottom-admin-bar.php
@@ -36,7 +36,7 @@ class BottomAdminBar {
     add_action( 'wp_enqueue_scripts', array(&$this, 'admin_bar_script_init'), 11 );
     add_action( 'get_header', array(&$this, 'remove_admin_bar_css') );
     add_action( 'wp_head', array(&$this, 'my_admin_bar_bump_cb') );
-    add_action( 'wp_head', array(&$this, 'keyboard_shortcut') );
+    add_action( 'wp_footer', array(&$this, 'keyboard_shortcut'), 21 );
   }
 
   /**


### PR DESCRIPTION
Changed hook to wp_footer at priority 21; enqueued scripts are executed at priority 20 in the footer (according to http://codex.wordpress.org/Plugin_API/Action_Reference/wp_footer), so this should always come after them if the theme developer has changed the jQuery script to enqueue in the footer.
