### PR TITLE
Fix deprecation notice on WP 4.5

### DIFF
--- a/bottom-admin-bar.php
+++ b/bottom-admin-bar.php
@@ -41,7 +41,7 @@ class BottomAdminBar {
 	 * Checking the 'Show Toolbar when viewing site' check box.
 	 */
 	public function show_toolbar_check() {
-		get_currentuserinfo();
+		wp_get_current_user();
 		if( 'true' !== get_user_meta( get_current_user_id(), 'show_admin_bar_front', 1 ) ) return;
 	}
 


### PR DESCRIPTION
replaced get_currentuserinfo() with wp_get_current_user() to comply with WP 4.5
